### PR TITLE
Set crontab every boot, give cron job environment variables

### DIFF
--- a/root/usr/local/bin/plex-sync-entrypoint
+++ b/root/usr/local/bin/plex-sync-entrypoint
@@ -1,9 +1,11 @@
 #!/bin/sh
 
-crontab -l | grep plex-sync-job || echo 'Installing cron job' && (crontab -l 2>/dev/null; echo "$CRON_SCHEDULE /usr/local/bin/plex-sync-job >> /var/log/cron.log 2>&1") | crontab -
+export -p > /root/project_env.sh
+
+echo 'Installing cron job' && crontab -l 2>/dev/null; echo "$CRON_SCHEDULE . /root/project_env.sh >> /var/log/cron.log 2>&1; /usr/local/bin/plex-sync-job >> /var/log/cron.log 2>&1" | crontab -
 
 [ ! -z "$INITIAL_RUN" ] && /usr/local/bin/plex-sync-job
 
 touch /var/log/cron.log
 
-rsyslogd && cron && tail -F /var/log/syslog /var/log/cron.log 2>/dev/null
+rsyslogd && cron && tail -F /var/log/syslog /var/log/cron.log 2>/dev/null 


### PR DESCRIPTION
From my testing, the initial plex-sync run would work, but then the subsequent cronjob runs wouldn't work and would just print running cronjob. Also, after every restart the crontab would contain one more entry for the cronjob. This PR ensures that the job is added at every boot and the old crontab entries are removed. It also changes the cronjob itself so that it loads the environment variables from the docker environment into the crontab environment, allowing plex-sync to run within the crontab environment correctly. I've ran and tested this locally and it works as expected, if you accept this PR and push it to docker hub that would be great. If not, i'll wait a couple weeks and then upload my fork to docker hub instead as from what I can tell this current container doesn't work at all after the initial run.